### PR TITLE
Honor existing "get" accessor when setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,15 +52,14 @@ function sideSet(obj, key, {before, after} = {}) {
   defineProperty(obj, key, {
     get: oldGet ? oldGet : function() { return sideStore(this)[key]; },
     set: function(value) {
-      const priv = sideStore(this);
-      const current = priv[key];
+      const current = this[key];
       if (before) {
         before.call(this, value, current, this);
       }
       if (oldPropDescriptor && oldPropDescriptor.set) {
         oldPropDescriptor.set.call(this, value);
       } else {
-        priv[key] = value;
+        sideStore(this)[key] = value;
       }
       if (after) {
         after.call(this, value, current, this);

--- a/test.js
+++ b/test.js
@@ -1,1 +1,28 @@
+const assert = require('assert');
 const setAside = require('./index');
+
+(function hasGet() {
+  var obj = Object.defineProperty({}, 'attr', {
+    get() {
+      return this._attr;
+    },
+    set(newValue) {
+      return this._attr = newValue;
+    },
+    configurable: true
+  });
+
+  obj.attr = 23;
+
+  setAside.afterSet(obj, 'attr', function() {
+    args = arguments;
+  });
+
+  assert.equal(obj.attr, 23);
+
+  obj.attr = 45;
+
+  assert.equal(args[0], 45);
+  assert.equal(args[1], 23);
+  assert.equal(obj.attr, 45);
+}());


### PR DESCRIPTION
When creating accessor functions, the library takes care to preserve
previously-existing `get` functions if they are available. For
consistency, the `set` function should likewise defer to the existing
implementation.
